### PR TITLE
Fix focus state crashes and improve keyboard dismissal on iOS

### DIFF
--- a/EasyTier/Components/AdaptiveNavigation.swift
+++ b/EasyTier/Components/AdaptiveNavigation.swift
@@ -9,20 +9,27 @@ struct AdaptiveNavigation<PrimaryView, SecondaryView, Enum>: View where PrimaryV
     @ViewBuilder var primaryColumn: PrimaryView
     @ViewBuilder var secondaryColumn: SecondaryView
     @Binding var showNav: Enum?
-    
+
     init(_ primary: PrimaryView, _ secondary: SecondaryView, showNav: Binding<Enum?>) {
         primaryColumn = primary
         secondaryColumn = secondary
         _showNav = showNav
     }
-    
+
     var body: some View {
         Group {
             if sizeClass == .regular {
                 HStack(spacing: 0) {
                     primaryColumn
                         .frame(maxWidth: columnMaxWidth)
-                    secondaryColumn
+                    ZStack(alignment: .topLeading) {
+                        secondaryColumn
+#if os(iOS)
+                        KeyboardDismissOverlay()
+                            .allowsHitTesting(true)
+#endif
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             } else {
                 primaryColumn
@@ -51,3 +58,58 @@ extension View {
         }
     }
 }
+
+#if os(iOS)
+struct KeyboardDismissOverlay: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = .clear
+        view.isUserInteractionEnabled = true
+
+        let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap))
+        tap.cancelsTouchesInView = false
+        tap.delegate = context.coordinator
+        view.addGestureRecognizer(tap)
+
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        @objc func handleTap() {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
+
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+            guard let overlayView = gestureRecognizer.view,
+                  let window = overlayView.window else { return false }
+
+            let locationInOverlay = touch.location(in: overlayView)
+            let locationInWindow = overlayView.convert(locationInOverlay, to: window)
+
+            // Temporarily disable the overlay so hitTest can see through it
+            let wasEnabled = overlayView.isUserInteractionEnabled
+            overlayView.isUserInteractionEnabled = false
+            let hitView = window.hitTest(locationInWindow, with: nil)
+            overlayView.isUserInteractionEnabled = wasEnabled
+
+            if let hitView = hitView {
+                var current: UIView? = hitView
+                while let v = current {
+                    if v is UITextField || v is UITextView {
+                        return false
+                    }
+                    current = v.superview
+                }
+            }
+
+            return true
+        }
+    }
+}
+#endif

--- a/EasyTier/Components/AdaptiveNavigation.swift
+++ b/EasyTier/Components/AdaptiveNavigation.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 struct AdaptiveNavigation<PrimaryView, SecondaryView, Enum>: View where PrimaryView: View, SecondaryView: View, Enum: Identifiable & Hashable {
 #if os(macOS)

--- a/EasyTier/Components/IPv4Field.swift
+++ b/EasyTier/Components/IPv4Field.swift
@@ -81,6 +81,9 @@ struct IPv4Field: View {
                 syncOctetsFromExternal()
             }
         }
+        .onDisappear {
+            focusedField = nil
+        }
     }
     
 #if os(iOS)
@@ -97,9 +100,15 @@ struct IPv4Field: View {
     }
 #endif
     
+    private func setFocusedField(_ field: Int?) {
+        Task { @MainActor in
+            focusedField = field
+        }
+    }
+
     private func processOctetInput(oldValue: String, newValue: String, at index: Int) {
         if oldValue == newValue { return }
-        
+
         if length != nil && newValue.contains("/") {
             if newValue.count > 4 {
                 parseAndDistribute(fullString: newValue)
@@ -108,11 +117,11 @@ struct IPv4Field: View {
             if !octets[index].isEmpty {
                 octets[index] = newValue.replacingOccurrences(of: "/", with: "")
                 updateIPBinding()
-                focusedField = 4
+                setFocusedField(4)
                 return
             }
         }
-        
+
         if newValue.contains(".") {
             if newValue.split(separator: ".").count > 1 {
                 parseAndDistribute(fullString: newValue)
@@ -121,46 +130,46 @@ struct IPv4Field: View {
             if !octets[index].isEmpty && index < 3 {
                 octets[index] = newValue.replacingOccurrences(of: ".", with: "")
                 updateIPBinding()
-                focusedField = index + 1
+                setFocusedField(index + 1)
                 return
             }
         }
-        
+
         let filtered = newValue.filter { "0123456789".contains($0) }
-        
+
         if filtered.isEmpty && !octets[index].isEmpty {
             octets[index] = ""
             updateIPBinding()
-            if index > 0 { focusedField = index - 1 }
+            if index > 0 { setFocusedField(index - 1) }
             return
         }
-        
+
         if let num = Int(filtered) {
             octets[index] = String(max(min(num, 255), 0))
-            
+
             if filtered.count >= 3 {
-                focusedField = index + 1
+                setFocusedField(index + 1)
             }
             updateIPBinding()
         }
     }
-    
+
     private func processLengthInput(_ newValue: String, binding: Binding<String>) {
         if newValue.isEmpty && !binding.wrappedValue.isEmpty {
             binding.wrappedValue = ""
-            focusedField = 3
+            setFocusedField(3)
             return
         }
-        
+
         let filtered = newValue.filter { "0123456789".contains($0) }
-        
+
         if let num = Int(filtered) {
             binding.wrappedValue = String(max(min(num, 32), 0))
         } else if filtered.isEmpty {
             binding.wrappedValue = ""
         }
     }
-    
+
     private func updateIPBinding() {
         self.ipAddress = octets.map {
             if let num = Int($0) {
@@ -168,7 +177,7 @@ struct IPv4Field: View {
             } else { "" }
         }.joined(separator: ".")
     }
-    
+
     private func syncOctetsFromExternal() {
         let parts = ipAddress.split(separator: ".")
         for (i, part) in parts.enumerated() {
@@ -178,15 +187,15 @@ struct IPv4Field: View {
             octets = ["", "", "", ""]
         }
     }
-    
+
     private func parseAndDistribute(fullString: String) {
         let components = fullString.split(separator: "/")
-        
+
         if components.count > 0 {
             let ipPart = String(components[0])
             let validIpChars = ipPart.filter { "0123456789.".contains($0) }
             self.ipAddress = validIpChars
-            
+
             let parts = validIpChars.split(separator: ".").map {
                 if let num = Int($0) {
                     String(max(min(num, 255), 0))
@@ -196,18 +205,18 @@ struct IPv4Field: View {
                 if i < 4 { octets[i] = String(part.prefix(3)) }
             }
         }
-        
+
         if let lengthBinding = length, components.count > 1 {
             let lengthPart = String(components[1]).prefix(2)
             if let num = Int(lengthPart) {
                 lengthBinding.wrappedValue = String(max(min(num, 32), 0))
             }
         }
-        
+
         if components.count > 1 && length != nil {
-            focusedField = 4
+            setFocusedField(4)
         } else {
-            focusedField = 3
+            setFocusedField(3)
         }
     }
 }

--- a/EasyTier/Components/IPv4Field.swift
+++ b/EasyTier/Components/IPv4Field.swift
@@ -101,9 +101,7 @@ struct IPv4Field: View {
 #endif
     
     private func setFocusedField(_ field: Int?) {
-        Task { @MainActor in
-            focusedField = field
-        }
+        focusedField = field
     }
 
     private func processOctetInput(oldValue: String, newValue: String, at index: Int) {

--- a/EasyTier/ContentView.swift
+++ b/EasyTier/ContentView.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 #if os(iOS)
 let columnMaxWidth: CGFloat = 450

--- a/EasyTier/ContentView.swift
+++ b/EasyTier/ContentView.swift
@@ -11,12 +11,14 @@ let columnMinWidth: CGFloat = 300
 struct ContentView<Manager: NetworkExtensionManagerProtocol>: View {
     @ObservedObject var manager: Manager
     @StateObject private var selectedSession = SelectedProfileSession()
-    
-#if os(macOS)
+
     enum TabItem: Hashable {
         case dashboard, log, settings
     }
+#if os(macOS)
     @State private var selectedTab: TabItem? = .dashboard
+#else
+    @State private var selectedTab: TabItem = .dashboard
 #endif
     
     var body: some View {
@@ -57,23 +59,29 @@ struct ContentView<Manager: NetworkExtensionManagerProtocol>: View {
         .navigationTitle("EasyTier")
         .frame(minWidth: 500, minHeight: 300)
 #else
-            TabView {
+            TabView(selection: $selectedTab) {
                 DashboardView(manager: manager, selectedSession: selectedSession)
                     .tabItem {
                         Image(systemName: "list.bullet.below.rectangle")
                         Text("main.dashboard")
                     }
+                    .tag(TabItem.dashboard)
                 LogView()
                     .tabItem {
                         Image(systemName: "rectangle.and.text.magnifyingglass")
                         Text("logging")
                     }
+                    .tag(TabItem.log)
                 SettingsView(manager: manager)
                     .tabItem {
                         Image(systemName: "gearshape")
                             .environment(\.symbolVariants, .none)
                         Text("settings")
                     }
+                    .tag(TabItem.settings)
+            }
+            .onChange(of: selectedTab) { _ in
+                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
             }
 #endif
     }

--- a/EasyTier/Utils/Compatibility.swift
+++ b/EasyTier/Utils/Compatibility.swift
@@ -40,5 +40,15 @@ extension View {
         return self
 #endif
     }
+
+    func dismissKeyboardOnTap() -> some View {
+#if os(iOS)
+        return self.onTapGesture {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
+#else
+        return self
+#endif
+    }
 }
 

--- a/EasyTier/Utils/Compatibility.swift
+++ b/EasyTier/Utils/Compatibility.swift
@@ -1,3 +1,6 @@
+#if canImport(UIKit)
+import UIKit
+#endif
 import SwiftUI
 
 #if os(iOS)

--- a/EasyTier/Views/DashboardView.swift
+++ b/EasyTier/Views/DashboardView.swift
@@ -89,6 +89,7 @@ struct DashboardView<Manager: NetworkExtensionManagerProtocol>: View {
 #endif
             }
         }
+        .dismissKeyboardOnTap()
     }
 
     func createProfile() {
@@ -253,6 +254,7 @@ struct DashboardView<Manager: NetworkExtensionManagerProtocol>: View {
             .formStyle(.grouped)
             .navigationTitle("device.management")
             .adaptiveNavigationBarTitleInline()
+            .dismissKeyboardOnTap()
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button {

--- a/EasyTier/Views/NetworkEditView.swift
+++ b/EasyTier/Views/NetworkEditView.swift
@@ -26,6 +26,7 @@ struct NetworkEditView: View {
             NavigationLink("port_forwards", value: EditPane.portForwards)
         }
         .scrollDismissesKeyboard(.immediately)
+        .dismissKeyboardOnTap()
 #else
         Form {
             basicSettings
@@ -63,6 +64,7 @@ struct NetworkEditView: View {
             }
         }
         .scrollDismissesKeyboard(.immediately)
+        .dismissKeyboardOnTap()
     }
 
     var basicSettings: some View {
@@ -280,6 +282,7 @@ struct NetworkEditView: View {
         }
         .navigationTitle("advanced_settings")
         .scrollDismissesKeyboard(.immediately)
+        .dismissKeyboardOnTap()
         .formStyle(.grouped)
     }
     
@@ -330,6 +333,7 @@ struct NetworkEditView: View {
         }
         .navigationTitle("dns_settings")
         .scrollDismissesKeyboard(.immediately)
+        .dismissKeyboardOnTap()
         .formStyle(.grouped)
     }
     
@@ -372,6 +376,7 @@ struct NetworkEditView: View {
         }
         .navigationTitle("route_settings")
         .scrollDismissesKeyboard(.immediately)
+        .dismissKeyboardOnTap()
         .sheet(isPresented: $showProxyCIDREditor) {
             proxyCIDREditor
         }
@@ -441,6 +446,7 @@ struct NetworkEditView: View {
         }
         .navigationTitle("port_forwards")
         .scrollDismissesKeyboard(.immediately)
+        .dismissKeyboardOnTap()
         .formStyle(.grouped)
     }
     
@@ -496,6 +502,7 @@ struct NetworkEditView: View {
             .formStyle(.grouped)
             .navigationTitle("common_text.edit_proxy_cidr")
             .adaptiveNavigationBarTitleInline()
+            .dismissKeyboardOnTap()
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button {

--- a/EasyTier/Views/SettingsView.swift
+++ b/EasyTier/Views/SettingsView.swift
@@ -67,6 +67,7 @@ struct SettingsView<Manager: NetworkExtensionManagerProtocol>: View {
             .formStyle(.grouped)
 #endif
         }
+        .dismissKeyboardOnTap()
         .alert(item: $settingsErrorMessage) { msg in
             Alert(title: Text("common.error"), message: Text(msg.text))
         }


### PR DESCRIPTION
As is implicated by the title, this PR fixes the issue #15. It resolves the focus state crash problems on iOS/iPadOS and introduce an overlay for iPad devices to dismiss the keyboard by tapping on the empty area.