### PR TITLE
feat(tunnel): route through an exit node on iOS

### DIFF
--- a/EasyTier/Utils/NetworkExtensionManager.swift
+++ b/EasyTier/Utils/NetworkExtensionManager.swift
@@ -204,6 +204,7 @@ class NetworkExtensionManager: NetworkExtensionManagerProtocol {
         if let routes = config.routes {
             options.routes = routes
         }
+        options.exitNodes = config.exitNodes
         if let logLevel = UserDefaults.standard.string(forKey: "logLevel"),
            let logLevel = LogLevel.init(rawValue: logLevel) {
             options.logLevel = logLevel

--- a/EasyTierNetworkExtension/BuilderHelper.swift
+++ b/EasyTierNetworkExtension/BuilderHelper.swift
@@ -90,6 +90,14 @@ func buildIPv4Routes(info: RunningInfo?, options: EasyTierOptions) -> [NEIPv4Rou
             logger.warning("buildIPv4Routes() no routes")
         }
     }
+    // An exit node does nothing on iOS without this. Elsewhere the core installs a default
+    // route itself; here includedRoutes is the only way a route reaches the tun device, and
+    // traffic that never enters the tun is never offered to the exit node.
+    if let exitNodes = options.exitNodes, !exitNodes.isEmpty,
+       let defaultRoute = normalizeCIDR("0.0.0.0/0") {
+        logger.info("buildIPv4Routes() exit node in use, adding a default route")
+        cidrs.insert(defaultRoute)
+    }
     var sortedCIDRs = Array(cidrs)
     sortedCIDRs.sort { $0.networkLength < $1.networkLength }
     var indicesToRemove = Set<Int>()

--- a/EasyTierShared/EasyTierShared.swift
+++ b/EasyTierShared/EasyTierShared.swift
@@ -23,6 +23,9 @@ public struct EasyTierOptions: Codable {
     public var logLevel: LogLevel = .info
     public var magicDNS: Bool = false
     public var dns: [String] = []
+    /// Optional so an always-on tunnel can still reconnect on a blob an older build wrote:
+    /// a synthesised Decodable throws on a missing non-optional key.
+    public var exitNodes: [String]?
 
     public init() {}
 }


### PR DESCRIPTION
`exit_nodes` has no effect on iOS. On other platforms the core installs a default route
itself; here the tun only ever receives what `includedRoutes` names, and traffic that
never enters the tun is never offered to the exit node.

Adds `0.0.0.0/0` when an exit node is configured, and carries `exit_nodes` through
`EasyTierOptions` so the extension can see it. `cidrToSubnetMask`, `ipv4MaskedSubnet`
and `ipv4SubnetsOverlap` already handle a prefix length of 0.

`exitNodes` is optional so an always-on tunnel can still reconnect on an options blob
written by an older build: a synthesised `Decodable` throws on a missing non-optional
key.