### PR TITLE
fix(log): present export errors instead of dropping them

### DIFF
--- a/EasyTier/Views/LogView.swift
+++ b/EasyTier/Views/LogView.swift
@@ -102,10 +102,16 @@ struct LogView<Manager: NetworkExtensionManagerProtocol>: View {
                 break
             }
         }
-        .alert(item: $tailer.errorMessage) { msg in
-            Alert(title: Text("common.error"), message: Text(msg.text))
-        }
-        .alert(item: $exportErrorMessage) { msg in
+        // One alert for the view. Two of them stacked here does not reliably present both, and
+        // it was the second that lost: every export error, including "Log file not found.",
+        // was dropped without a trace and the share button looked dead.
+        .alert(item: Binding(
+            get: { tailer.errorMessage ?? exportErrorMessage },
+            set: { _ in
+                tailer.errorMessage = nil
+                exportErrorMessage = nil
+            }
+        )) { msg in
             Alert(title: Text("common.error"), message: Text(msg.text))
         }
 #if os(iOS)


### PR DESCRIPTION
`LogView` has two `.alert(item:)` modifiers on the same view. SwiftUI does not reliably
present both, and it is the second that loses, so every export error -- including
"Log file not found." -- was discarded without a trace and the share button looked like
it did nothing.

One alert, fed by whichever of the two sources has a message.